### PR TITLE
Run cucumber automatically as GitHub Action

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -1,4 +1,4 @@
-name: Pylint and PyTest
+name: Pylint, PyTest, and Cucumber
 
 on: [push]
 

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -32,3 +32,6 @@ jobs:
     - name: Run unit tests via pytest
       run: |
         pytest --cov-report term-missing --cov=rc_car --cov-config=.coveragerc tests
+    - name: Run cucumber
+      run: |
+        behave


### PR DESCRIPTION
The aim of this PR is to run cucumber automatically as a GitHub Action for increased visibility of the status of its checks.